### PR TITLE
Upgraded to Structurizr 1.11.0 in JRE 16 and Gradle 6.9.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: CI to Docker hub
 env:
   REGISTRY: leopoldodonnell
-  CLI_VERSION: v1.6.0
+  CLI_VERSION: 1.11.0
 
 on:
   push:
@@ -33,4 +33,4 @@ jobs:
         push: true
         build-args: |
           CLI_VERSION=${{ env.CLI_VERSION }}
-        tags: ${{ env.REGISTRY }}/structurizr-cli:${{ env.CLI_VERSION }}
+        tags: ${{ env.REGISTRY }}/structurizr-cli:v${{ env.CLI_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-ARG GRADLE_VERSION='6.3'
-ARG CLI_VERION=v.1.6.0
+ARG GRADLE_VERSION='6.9'
+ARG CLI_VERSION=1.11.0
 
-FROM gradle:${GRADLE_VERSION}-jdk8 as build
+FROM gradle:${GRADLE_VERSION}-jdk11 as build
+ARG GRADLE_VERSION
+ARG CLI_VERSION
 
 RUN set -ex \
     ; git clone https://github.com/structurizr/cli.git /cli \
     ; cd /cli \
-    ; git checkout ${CLI_VERION}
+    ; git checkout v${CLI_VERSION}
 
 WORKDIR /cli
 USER root
@@ -14,13 +16,13 @@ USER root
 ARG GRADLE_BUILD_COMMAND="bootJar"
 RUN gradle test --no-daemon --console plain
 RUN gradle ${GRADLE_BUILD_COMMAND} --refresh-dependencies --no-daemon --console plain
-RUN find . -name '*.jar'
+RUN echo $(find . -name '*.jar')
 
-FROM openjdk:8-jre-alpine as run
+FROM adoptopenjdk:16-jre as run
+ARG CLI_VERSION
 
 WORKDIR /
-COPY --from=build /cli/build/libs/structurizr-cli-1.6.0.jar /cli/lib/structurizr-dsl-1.0.0.jar ./
-RUN mkdir -p /workdir
-WORKDIR /workdir
+COPY --from=build /cli/build/libs/structurizr-cli-${CLI_VERSION}.jar .
+RUN ln -s /structurizr-cli-${CLI_VERSION}.jar /structurizr-cli.jar
 
-ENTRYPOINT ["java", "-jar", "/structurizr-cli-1.6.0.jar" ]
+ENTRYPOINT ["java", "-jar", "/structurizr-cli.jar" ]


### PR DESCRIPTION
Changes:

- Upgraded to use the latest version of Structurizr to 1.11.0
- Removed the DSL engine as it is no longer part of the CLI.
- Upgraded Gradle to use the latest stable from the 6.x line. Unfortuantely Structurizer is not compatible with 7.1.x yet.
- Made the `CLI_VERSION` reusable.
- Changed to use Java 16 instead of 8. It is working just fine with it, so I see no reason why we should stick to this very old JVM.